### PR TITLE
Fix bottleneck

### DIFF
--- a/src/caseta/remote.rs
+++ b/src/caseta/remote.rs
@@ -1,7 +1,5 @@
 use crate::client::dispatcher::{DeviceAction, DeviceActionMessage};
-use crate::client::hue::HueClient;
 use crate::config::caseta_remote::{ButtonAction, ButtonId};
-use crate::config::scene::Room;
 use anyhow::{bail, ensure};
 use anyhow::{Ok, Result};
 use std::fmt::{Display, Formatter};
@@ -12,7 +10,7 @@ use tokio::time::{sleep, Instant};
 use tracing::{debug, error, instrument, warn};
 
 const DOUBLE_CLICK_WINDOW: Duration = Duration::from_millis(500);
-const REMOTE_WATCHER_LOOP_SLEEP_DURATION: Duration = Duration::from_millis(500);
+const REMOTE_WATCHER_LOOP_SLEEP_DURATION: Duration = Duration::from_millis(250);
 
 // note: it seems like caseta has some built in timeout for long presses.
 // when you press and hold the remote, it blinks once when you first press it, and then again after about 5 seconds

--- a/src/client/dispatcher.rs
+++ b/src/client/dispatcher.rs
@@ -386,7 +386,11 @@ impl DeviceActionDispatcher {
     fn get_previous_scene<'a>(room: &'a Room, current_scene: &Scene) -> &'a Scene {
         let position = Self::get_scene_index(room, current_scene);
         let scene_count = room.scenes.len();
-        room.scenes.get((position - 1) % scene_count).unwrap()
+        let previous_scene_position = match position {
+            0 => scene_count - 1,
+            _ => (position - 1) % scene_count
+        };
+        room.scenes.get(previous_scene_position).unwrap()
     }
 
     fn get_first_scene<'a>(room: &'a Room) -> &'a Scene {

--- a/src/client/dispatcher.rs
+++ b/src/client/dispatcher.rs
@@ -11,7 +11,7 @@ use uuid::Uuid;
 use super::model::hue::{GroupedLight, HueResponse};
 use super::room_state::CurrentRoomStateCache;
 
-const BRIGHTNESS_UPDATE_AMOUNT: f32 = 5.0;
+const BRIGHTNESS_UPDATE_AMOUNT: f32 = 10.0;
 const MAXIMUM_BRIGHTNESS_PERCENT: f32 = 100.0;
 const MINIMUM_BRIGHTNESS_PERCENT: f32 = 1.0;
 

--- a/src/client/hue.rs
+++ b/src/client/hue.rs
@@ -82,33 +82,6 @@ impl HueClient {
     }
 
     #[instrument(level = "debug")]
-    pub async fn turn_on(
-        &self,
-        grouped_light_room_id: Uuid,
-    ) -> anyhow::Result<HueResponse<GroupedLight>> {
-        let request_body = GroupedLightPutBody::builder().on(LightGroupOn::ON).build();
-
-        let url = self.build_grouped_light_url(grouped_light_room_id);
-        let response = self.http_client.put(url).json(&request_body).send().await?;
-        let status = response.status();
-        if !status.is_success() {
-            let response_body = &response.text().await?;
-            error!(
-                "there was a problem turning on the grouped_light {}. code: {}, body: {}",
-                grouped_light_room_id, status, response_body
-            );
-            anyhow::bail!(
-                "there was a problem turning on the grouped light {}. code: {}, body: {}",
-                grouped_light_room_id,
-                status,
-                response_body
-            )
-        }
-        // now the light should be on, so let's get the state of the grouped_light
-        self.get_grouped_light(grouped_light_room_id).await
-    }
-
-    #[instrument(level = "debug")]
     pub async fn update_brightness(
         &self,
         grouped_light_room_id: Uuid,
@@ -164,7 +137,7 @@ impl HueClient {
     }
 
     #[instrument(level = "debug")]
-    pub async fn recall_scene(&self, scene_id: &Uuid, brightness: f32) -> Result<()> {
+    pub async fn recall_scene(&self, scene_id: &Uuid, brightness: Option<f32>) -> Result<()> {
         let url = self
             .base_url
             .join(format!("scene/{}", scene_id).as_str())

--- a/src/client/hue.rs
+++ b/src/client/hue.rs
@@ -1,7 +1,7 @@
 use anyhow::{anyhow, bail, Ok, Result};
 use log::error;
 use reqwest::header::{HeaderMap, HeaderValue};
-use reqwest::{Client, Response, Url};
+use reqwest::{Client, Url};
 use std::collections::HashMap;
 use tracing::{debug, instrument};
 use url::Host;
@@ -18,7 +18,6 @@ const HUE_AUTH_KEY_HEADER: &str = "hue-application-key";
 #[derive(Debug)]
 pub struct HueClient {
     base_url: Url,
-    auth_key: String,
     http_client: Client,
 }
 
@@ -39,12 +38,11 @@ impl HueClient {
             .expect("unable to parse the hue base URL");
         HueClient {
             base_url,
-            auth_key,
             http_client,
         }
     }
 
-    #[instrument]
+    #[instrument(level = "debug")]
     pub async fn get_grouped_light(
         &self,
         grouped_light_room_id: Uuid,
@@ -61,6 +59,7 @@ impl HueClient {
             .map_err(|e| anyhow!(e))
     }
 
+    #[instrument(level = "debug")]
     pub async fn get_rooms(&self) -> Result<HashMap<Uuid, HueRoom>> {
         let url = self
             .base_url
@@ -82,6 +81,7 @@ impl HueClient {
             .expect("unable to build the request URI")
     }
 
+    #[instrument(level = "debug")]
     pub async fn turn_on(
         &self,
         grouped_light_room_id: Uuid,
@@ -108,6 +108,7 @@ impl HueClient {
         self.get_grouped_light(grouped_light_room_id).await
     }
 
+    #[instrument(level = "debug")]
     pub async fn update_brightness(
         &self,
         grouped_light_room_id: Uuid,
@@ -138,6 +139,7 @@ impl HueClient {
         Ok(())
     }
 
+    #[instrument(level = "debug")]
     pub async fn turn_off(&self, grouped_light_room_id: Uuid) -> anyhow::Result<()> {
         let url = self.build_grouped_light_url(grouped_light_room_id);
         let request_body = GroupedLightPutBody::builder().on(LightGroupOn::OFF).build();
@@ -161,6 +163,7 @@ impl HueClient {
         Ok(())
     }
 
+    #[instrument(level = "debug")]
     pub async fn recall_scene(&self, scene_id: &Uuid, brightness: f32) -> Result<()> {
         let url = self
             .base_url

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,17 +15,15 @@ use caseta_listener::caseta::connection::{
     CasetaConnection, CasetaConnectionError, DefaultTcpSocketProvider,
 };
 use caseta_listener::caseta::message::Message;
-use caseta_listener::caseta::remote::{remote_watcher_loop, RemoteHistory, RemoteWatcher};
-use caseta_listener::client::dispatcher::{
-    dispatcher_loop, DeviceActionDispatcher, DeviceActionMessage,
-};
+use caseta_listener::caseta::remote::{remote_watcher_loop, RemoteWatcher};
+use caseta_listener::client::dispatcher::{dispatcher_loop, DeviceActionDispatcher};
 use caseta_listener::client::hue::HueClient;
 use caseta_listener::config::caseta_auth_configuration::get_caseta_auth_configuration;
 use caseta_listener::config::caseta_remote::{
     get_caseta_remote_configuration, ButtonAction, CasetaRemote, RemoteConfiguration, RemoteId,
 };
 use caseta_listener::config::hue_auth_configuration::get_hue_auth_configuration;
-use caseta_listener::config::scene::{get_room_configurations, HomeConfiguration, Room, Topology};
+use caseta_listener::config::scene::{get_room_configurations, HomeConfiguration, Topology};
 
 type RemoteWatcherDb = HashMap<RemoteId, Arc<RemoteWatcher>>;
 
@@ -60,7 +58,7 @@ async fn watch_caseta_events() -> Result<()> {
     let mut connection = CasetaConnection::new(caseta_hub_settings, &tcp_socket_provider);
     connection.initialize().await?;
 
-    let (action_sender, mut action_receiver) = mpsc::channel(64);
+    let (action_sender, action_receiver) = mpsc::channel(64);
     let mut remote_watchers: RemoteWatcherDb = HashMap::new();
     let hue_client = HueClient::new(
         hue_auth_configuration.host,


### PR DESCRIPTION
I was using multi-producer, single consumer channel to listen to events from (potentially several) different caseta remotes, but all of the single consumer events were going through [this loop](https://github.com/dkulla01/caseta_listener/blob/78d9ea49c1857613b372469b89ef8bbb80f69673/src/client/dispatcher.rs#L359-L385). That loop doesn't spawn any new tasks to actually execute the actions, so it behaves like a single-threaded, blocking executor. And that sort of negates all of the benefits of the other async IO in this project.

Now, this will spawn a new task to handle each action. This could lead to some race conditions without additional locking (like out of order brightness changes: 50% to 70% to 60% depending on which brightness requests complete first), but this is a hobby project for changing light brightness, so inconsistencies aren't a huge deal. One way to fix this would be a map of mutexes, one for each room. and only one task can hold the lock for any given room at any given time.

EDIT: I addressed the race condition with the aforementioned mutexes, and I also fixed some scene-change semantics to fix a bug with negative array index lookups.
