### PR TITLE
don't automatically restart containers

### DIFF
--- a/docker/docker_compose_aarch64.yaml
+++ b/docker/docker_compose_aarch64.yaml
@@ -3,6 +3,9 @@ version: '3.8'
 services:
   caseta_listener:
     image: caseta_listener_aarch64:latest
+    deploy:
+      restart_policy:
+        condition: none
     environment:
       - CASETA_LISTENER_REMOTE_CONFIG_FILE=/etc/caseta_listener/config/caseta_remote_configuration.yaml
       - CASETA_LISTENER_SCENE_CONFIG_FILE=/etc/caseta_listener/config/caseta_listener_scenes.yaml


### PR DESCRIPTION
if there's an issue, let's just replace the container with a new one.

This is important because we sometimes ended up with multiple containers. the service configuration specifies that we should have one replica. when we restarted a container in the past, the service manager would think that we had no replicas up, so it created a new container to satisfy the required replicas. then the restarting container came back on line, leading to two replicas running when only one was specified.