### PR TITLE
use explicitly versioned docker image

### DIFF
--- a/docker/docker_compose_aarch64.yaml
+++ b/docker/docker_compose_aarch64.yaml
@@ -2,7 +2,7 @@ version: '3.8'
 
 services:
   caseta_listener:
-    image: caseta_listener_aarch64:latest
+    image: caseta_listener_aarch64:2023-03-15.PR-8
     deploy:
       restart_policy:
         condition: none


### PR DESCRIPTION
someimage:latest doesn't mean what I thought it meant. It's just the latest version of an image to be built without an explicit tag.

using an explicit tag is more predictable